### PR TITLE
Use trim() on VERSION file

### DIFF
--- a/src/Events/Event.php
+++ b/src/Events/Event.php
@@ -11,7 +11,7 @@ class Event extends PhpObj {
      * @return [String => Mixed]
      */
     public function read(array $opts) {
-        $version = str_replace(PHP_EOL, '', file_get_contents(__DIR__.'/../../VERSION'));
+        $version = trim(file_get_contents(__DIR__.'/../../VERSION'));
         $opts['info']->{'https://github.com/LearningLocker/Moodle-xAPI-Translator'} = $version;
         $app_name = $opts['app']->fullname ?: 'A Moodle site';
         return [[


### PR DESCRIPTION
Hi, here's a patch for this library to fix the trimming of the VERSION file, similar to https://github.com/LearningLocker/xAPI-Recipe-Emitter/pull/18