### PR TITLE
Updated createEvents() to accept multiple events

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -48,25 +48,25 @@ class Controller extends PhpObj {
 
     /**
      * Creates a new event.
-     * @param [String => Mixed] $opts
+     * @param [String => Mixed] $events
      * @return [String => Mixed]
      */
-    public function createEvents(array $opts) {
-        $route = isset($opts['event']['eventname']) ? $opts['event']['eventname'] : '';
-        if (isset(static::$routes[$route])) {
-            $results = [];
-                $route_events = is_array(static::$routes[$route]) ? static::$routes[$route] : [static::$routes[$route]];
-                foreach ($route_events as $route_event) {
-                try {
-                    $event = '\MXTranslator\Events\\'.$route_event;
-                    foreach ((new $event())->read($opts) as $index => $result) {
-                         array_push($results, $result);
-                     }
-                } catch (UnnecessaryEvent $ex) {}
-          }
-          return $results;
-        } else {
-          return [];
+    public function createEvents(array $events) {
+        $results = [];
+        foreach ($events as $index => $opts) {
+            $route = isset($opts['event']['eventname']) ? $opts['event']['eventname'] : '';
+            if (isset(static::$routes[$route])) {
+                    $route_events = is_array(static::$routes[$route]) ? static::$routes[$route] : [static::$routes[$route]];
+                    foreach ($route_events as $route_event) {
+                    try {
+                        $event = '\MXTranslator\Events\\'.$route_event;
+                        foreach ((new $event())->read($opts) as $index => $result) {
+                             array_push($results, $result);
+                         }
+                    } catch (UnnecessaryEvent $ex) {}
+                }
+            }
         }
+        return $results;
     }
 }


### PR DESCRIPTION
Hi, here is a patch to add support for multiple events, to help solve jlowe64/moodle-logstore_xapi#43. Just to note, this breaks backwards compatibility with the existing createEvents() method, which was introduced in https://github.com/LearningLocker/Moodle-xAPI-Translator/commit/17133fff7da10707a6dc07b63c60cff4bec5808b