### PR TITLE
updated naming used in unit tests to match PR47

### DIFF
--- a/tests/AttemptStartedTest.php
+++ b/tests/AttemptStartedTest.php
@@ -39,7 +39,7 @@ class AttemptStartedTest extends ModuleViewedTest {
         $ext_key = 'http://lrs.learninglocker.net/define/extensions/moodle_attempt';
         $this->assertEquals($input->url, $output['attempt_url']);
         $this->assertEquals($input->name, $output['attempt_name']);
-        $this->assertEquals(static::$xapi_type.$input->type, $output['attempt_type']);
+        $this->assertEquals(static::$xapiType.$input->type, $output['attempt_type']);
         $this->assertEquals($input, $output['attempt_ext']);
         $this->assertEquals($ext_key, $output['attempt_ext_key']);
     }

--- a/tests/DiscussionViewedTest.php
+++ b/tests/DiscussionViewedTest.php
@@ -38,7 +38,7 @@ class DiscussionViewedTest extends ModuleViewedTest {
         $this->assertEquals($input->url, $output[$type.'_url']);
         $this->assertEquals($input->name, $output[$type.'_name']);
         $this->assertEquals('A Moodle discussion.', $output[$type.'_description']);
-        $this->assertEquals(static::$xapi_type.$input->type, $output[$type.'_type']);
+        $this->assertEquals(static::$xapiType.$input->type, $output[$type.'_type']);
         $this->assertEquals($input, $output[$type.'_ext']);
         $this->assertEquals($ext_key, $output[$type.'_ext_key']);
     }

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -3,7 +3,7 @@ use \PHPUnit_Framework_TestCase as PhpUnitTestCase;
 use \MXTranslator\Events\Event as Event;
 
 abstract class EventTest extends PhpUnitTestCase {
-    protected static $xapi_type = 'http://lrs.learninglocker.net/define/type/moodle/';
+    protected static $xapiType = 'http://lrs.learninglocker.net/define/type/moodle/';
     protected static $recipe_name;
 
     /**
@@ -119,7 +119,7 @@ abstract class EventTest extends PhpUnitTestCase {
         $this->assertEquals($input->url, $output[$type.'_url']);
         $this->assertEquals($input->fullname, $output[$type.'_name']);
         $this->assertEquals(strip_tags($input->summary), $output[$type.'_description']);
-        $this->assertEquals(static::$xapi_type.$input->type, $output[$type.'_type']);
+        $this->assertEquals(static::$xapiType.$input->type, $output[$type.'_type']);
         $this->assertEquals($input, $output[$type.'_ext']);
         $this->assertEquals($ext_key, $output[$type.'_ext_key']);
     }

--- a/tests/FeedbackSubmittedTest.php
+++ b/tests/FeedbackSubmittedTest.php
@@ -71,7 +71,7 @@ class FeedbackSubmittedTest extends ModuleViewedTest {
         $ext_key = 'http://lrs.learninglocker.net/define/extensions/moodle_feedback_attempt';
         $this->assertEquals($input->url, $output['attempt_url']);
         $this->assertEquals($input->name, $output['attempt_name']);
-        $this->assertEquals(static::$xapi_type.$input->type, $output['attempt_type']);
+        $this->assertEquals(static::$xapiType.$input->type, $output['attempt_type']);
         $this->assertEquals($input, $output['attempt_ext']);
         $this->assertEquals($ext_key, $output['attempt_ext_key']);
     }

--- a/tests/ModuleViewedTest.php
+++ b/tests/ModuleViewedTest.php
@@ -37,7 +37,7 @@ class ModuleViewedTest extends CourseViewedTest {
         $this->assertEquals($input->url, $output[$type.'_url']);
         $this->assertEquals($input->name, $output[$type.'_name']);
         $this->assertEquals($input->intro, $output[$type.'_description']);
-        $this->assertEquals(static::$xapi_type.$input->type, $output[$type.'_type']);
+        $this->assertEquals(static::$xapiType.$input->type, $output[$type.'_type']);
         $this->assertEquals($input, $output[$type.'_ext']);
         $this->assertEquals($ext_key, $output[$type.'_ext_key']);
     }


### PR DESCRIPTION
Based on failed testing in logstore plugin, I believe this may be what is causing the issue. PR #47 adjust some of the $xapi_type variables to $xapiType. The tests associated with that change were missed.