### PR TITLE
Add support for H5P xAPI events

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -44,7 +44,8 @@ class Controller extends PhpObj {
         '\mod_facetoface\event\cancel_booking' => 'FacetofaceUnenrol',
         '\mod_facetoface\event\take_attendance' => 'FacetofaceAttend',
         '\mod_scorm\event\scoreraw_submitted' => 'ScormScoreRawSubmitted',
-        '\mod_scorm\event\status_submitted' => 'ScormStatusSubmitted'
+        '\mod_scorm\event\status_submitted' => 'ScormStatusSubmitted',
+        '\mod_hvp\event\hvp_xapi' => 'H5PxAPIEvent'
     ];
 
     /**

--- a/src/Events/H5PxAPIEvent.php
+++ b/src/Events/H5PxAPIEvent.php
@@ -1,0 +1,44 @@
+<?php namespace MXTranslator\Events;
+use \MXTranslator\Repository as Repository;
+use \stdClass as PhpObj;
+
+class H5PxAPIEvent extends PhpObj {
+    protected static $xapi_type = 'http://lrs.learninglocker.net/define/type/moodle/';
+
+    /**
+     * Reads data for an event.
+     * @param [String => Mixed] $opts
+     * @return [String => Mixed]
+     */
+    public function read(array $opts) {
+        $version = trim(file_get_contents(__DIR__.'/../../VERSION'));
+        $opts['info']->{'https://github.com/LearningLocker/Moodle-xAPI-Translator'} = $version;
+        $app_name = $opts['app']->fullname ?: 'A Moodle site';
+
+        return [[
+            'recipe' => 'hvp_xapi',
+            'user_id' => $opts['user']->id,
+            'user_url' => $opts['user']->url,
+            'user_name' => $opts['user']->fullname,
+            'context_lang' => is_null($opts['course']->lang)
+                || $opts['course']->lang === '' ? "en" : $opts['course']->lang,
+            'context_platform' => 'Moodle',
+            'context_ext' => $opts['event'],
+            'context_ext_key' => 'http://lrs.learninglocker.net/define/extensions/moodle_logstore_standard_log',
+            'context_info' => $opts['info'],
+            'time' => date('c', $opts['event']['timecreated']),
+            'app_url' => $opts['app']->url,
+            'app_name' => $app_name,
+            'app_description' => strip_tags($opts['app']->summary) ?: $app_name,
+            'app_type' => 'http://id.tincanapi.com/activitytype/site',
+            'app_ext' => $opts['app'],
+            'app_ext_key' => 'http://lrs.learninglocker.net/define/extensions/moodle_course',
+            'source_url' => 'http://moodle.org',
+            'source_name' => 'Moodle',
+            'source_description' => 'Moodle is a open source learning platform designed to provide educators,'
+                .' administrators and learners with a single robust, secure and integrated system'
+                .' to create personalised learning environments.',
+            'source_type' => 'http://id.tincanapi.com/activitytype/source'
+        ]];
+    }
+}


### PR DESCRIPTION
This PR is part of a set (Moodle-Log-Expander + Moodle-xAPI-Translator + xAPI-Recipe-Emitter ), which is complementing the changes made in h5p/h5p-moodle-plugin#114 as part of the Israeli Open University Academic English project (http://study.onl.co.il)

Please review and see if you can merge.